### PR TITLE
Add initial query providers

### DIFF
--- a/Gentron.Library/DatabaseSource.ts
+++ b/Gentron.Library/DatabaseSource.ts
@@ -1,19 +1,17 @@
-﻿//import * as MsSql from "mssql/msnodesqlv8";
-import { ActiveConnectionGroupConverter, FileJsonConverter } from "./converters";
+﻿import { ActiveConnectionGroupConverter, FileJsonConverter } from "./converters";
 import { ConnectionGroup, DatabaseConnection, File, Utilities } from "./";
 import { InfoMessages } from "./constants";
 import { JsonConverter, JsonElementType, JsonObject, JsonProperty, JsonType } from "ta-json";
 import { Result, TDataSourceResult } from "./results";
+import IQueryProvider from "./queryProviders/IQueryProvider";
 import SourceBase from "./SourceBase";
-//const sql = require('mssql/msnodesqlv8');
 
 @JsonObject()
 export default class DatabaseSource extends SourceBase<DatabaseSource> {
     /*
      *  Properties & Fields 
      */
-    private static readonly _jsonColumnId: string = "JSON_F52E2B61-18A1-11d1-B105-00805F49916B";
-    private static readonly _xmlColumnId: string = "XML_F52E2B61-18A1-11d1-B105-00805F49916B";
+    private static _msSqlQueryProvider: IQueryProvider;
 
     @JsonProperty()
     @JsonElementType(ConnectionGroup)
@@ -53,92 +51,9 @@ export default class DatabaseSource extends SourceBase<DatabaseSource> {
     }
 
 
-    private async onExecuteQueryFail(data: any, message: string, formatResults: boolean): Promise<Result<TDataSourceResult>> {
-        const error = {
-            Error: {
-                Message: message,
-                Data: `${data}`
-            }
-        };
-
-        const ret: TDataSourceResult = {
-            Json: (formatResults)
-                ? JSON.stringify(error, null, 4)
-                : JSON.stringify(error),
-            Object: null,
-            Xml: await Utilities.jsonToXmlStr(error, formatResults)
-        };
-
-        return Result.fail<TDataSourceResult>(message, ret);
+    public async executeScript(): Promise<Result<TDataSourceResult>> {
+        return await DatabaseSource._msSqlQueryProvider.executeQuery(this.ActiveConnectionGroup.Connections[0].ConnectionString, this.Script.Contents, true);
     }
-
-
-    //public async executeQuery(formatResults: boolean = true): Promise<Result<TDataSourceResult>> {
-    //    const connStr: string = this.ActiveConnectionGroup.Connections[0].ConnectionString;
-    //    const queryStr: string = this.Script.Contents;
-
-    //    let connPool: MsSql.ConnectionPool = null as any as MsSql.ConnectionPool;
-    //    let recordsets: MsSql.IRecordSet<any>;
-
-    //    try {
-    //        connPool = await new MsSql.ConnectionPool(connStr);
-    //        await connPool.connect();
-    //        const result: MsSql.IResult<any> = await new MsSql.Request(connPool).query(queryStr);
-    //        recordsets = await result.recordset;
-    //    }
-    //    catch (e) {
-    //        return await this.onExecuteQueryFail(queryStr, Utilities.getErrorMessage(e), formatResults);
-    //    }
-    //    finally {
-    //        if (Utilities.hasValue(connPool) && connPool.connected) {
-    //            await connPool.close();
-    //        }
-    //    }
-
-    //    if (!Utilities.hasValue(recordsets)) {
-    //        return await this.onExecuteQueryFail(queryStr, InfoMessages.QUERY_RESULTS_NULL, formatResults);
-    //    }
-
-    //    if (recordsets.length === 1) {
-    //        const recordset: any = recordsets[0];
-
-    //        const resultAsJson: any = recordset[DatabaseSource._jsonColumnId];
-    //        if (Utilities.hasValue(resultAsJson)) {
-    //            const ret: TDataSourceResult = {
-    //                Json: (formatResults)
-    //                    ? JSON.stringify(resultAsJson, null, 4)
-    //                    : JSON.stringify(resultAsJson),
-    //                Object: resultAsJson,
-    //                Xml: await Utilities.jsonStrToXmlStr(JSON.stringify(resultAsJson), formatResults)
-    //            };
-
-    //            return Result.ok<TDataSourceResult>(ret);
-    //        }
-
-    //        const resultAsXml: any = recordset[DatabaseSource._xmlColumnId];
-    //        if (Utilities.hasValue(resultAsXml)) {
-    //            const ret: TDataSourceResult = {
-    //                Json: Utilities.xmlStrToJsonStr(resultAsXml, formatResults),
-    //                Object: resultAsXml,
-    //                Xml: (formatResults)
-    //                    ? await Utilities.formatXml(resultAsXml)
-    //                    : resultAsXml
-    //            };
-
-    //            return Result.ok<TDataSourceResult>(ret);
-    //        }
-    //    }
-
-    //    const ret: TDataSourceResult = {
-    //        Json: (formatResults)
-    //            ? JSON.stringify(recordsets, null, 4)
-    //            : JSON.stringify(recordsets),
-    //        Object: recordsets,
-    //        Xml: await Utilities.jsonStrToXmlStr(JSON.stringify(recordsets), formatResults)
-    //    };
-
-    //    return Result.ok<TDataSourceResult>(ret);
-    //}
 
 
     public update(databaseSource: DatabaseSource): void {

--- a/Gentron.Library/Gentron.Library.njsproj
+++ b/Gentron.Library/Gentron.Library.njsproj
@@ -122,6 +122,12 @@
     <TypeScriptCompile Include="OutputPathGroup.ts">
       <SubType>Code</SubType>
     </TypeScriptCompile>
+    <TypeScriptCompile Include="queryProviders\IQueryProvider.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
+    <TypeScriptCompile Include="queryProviders\MsSqlQueryProvider.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
     <TypeScriptCompile Include="results\index.ts">
       <SubType>Code</SubType>
     </TypeScriptCompile>
@@ -158,6 +164,7 @@
     <Folder Include="abstract\" />
     <Folder Include="constants\" />
     <Folder Include="converters\" />
+    <Folder Include="queryProviders\" />
     <Folder Include="results\" />
     <Folder Include="types\" />
   </ItemGroup>

--- a/Gentron.Library/package-lock.json
+++ b/Gentron.Library/package-lock.json
@@ -116,13 +116,13 @@
       "integrity": "sha512-VTxuNFcHOD4WcY/RfeF1pq0jkbDBAOMourkcyHGWDPcZXtXcqhE5MHtor1q2VcVMwKy7+UBcUZNGzobvkdjSyQ=="
     },
     "mssql": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/mssql/-/mssql-4.2.1.tgz",
-      "integrity": "sha512-89mJcK/xgcsRdlCfEZxRsE93NKZnZJFSASy7Eiw4Bx6exvkGb9Kd1ey9d9/jODTFssoZ3U0OOFK3wabYMpJypQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-4.2.3.tgz",
+      "integrity": "sha512-GocHjqx2qaIQ/FwJTnLCoscrnbROCgSJfgpxoPun7rDpJkDS4b82sZ+lh/3hH+UuTC7T4f7VtJO5GLA6VyWfCw==",
       "requires": {
-        "debug": "^3.1.0",
+        "debug": "^3.2.6",
         "generic-pool": "^3.4.2",
-        "tedious": "^2.6.4"
+        "tedious": "^2.7.1"
       }
     },
     "native-duplexpair": {

--- a/Gentron.Library/package.json
+++ b/Gentron.Library/package.json
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "msnodesqlv8": "^0.6.9",
-    "mssql": "4.2.1"
+    "mssql": "^4.2.3"
   }
 }

--- a/Gentron.Library/queryProviders/IQueryProvider.ts
+++ b/Gentron.Library/queryProviders/IQueryProvider.ts
@@ -1,0 +1,5 @@
+﻿import { Result, TDataSourceResult } from "../results";
+
+export default interface IQueryProvider {
+    executeQuery(connStr: string, queryStr: string, formatResults: boolean): Promise<Result<TDataSourceResult>>;
+}

--- a/Gentron.Library/queryProviders/MsSqlQueryProvider.ts
+++ b/Gentron.Library/queryProviders/MsSqlQueryProvider.ts
@@ -1,0 +1,106 @@
+﻿import { TDataSourceResult, Result } from "../results";
+import { Utilities } from "../";
+import { InfoMessages } from "../constants";
+
+import * as MsSql from "mssql/msnodesqlv8";
+import IQueryProvider from "./IQueryProvider";
+
+export default class MsSqlQueryProvider implements IQueryProvider {
+    /*
+     *  Properties & Fields 
+     */
+    private static readonly _jsonColumnId: string = "JSON_F52E2B61-18A1-11d1-B105-00805F49916B";
+    private static readonly _xmlColumnId: string = "XML_F52E2B61-18A1-11d1-B105-00805F49916B";
+
+
+    /*
+     *  Constructors 
+     */
+
+
+    /*
+     *  Methods
+     */
+    private async onExecuteQueryFail(data: any, message: string, formatResults: boolean): Promise<Result<TDataSourceResult>> {
+        const error = {
+            Error: {
+                Message: message,
+                Data: `${data}`
+            }
+        };
+
+        const ret: TDataSourceResult = {
+            Json: (formatResults)
+                ? JSON.stringify(error, null, 4)
+                : JSON.stringify(error),
+            Object: null,
+            Xml: await Utilities.jsonToXmlStr(error, formatResults)
+        };
+
+        return Result.fail<TDataSourceResult>(message, ret);
+    }
+
+    public async executeQuery(connStr: string, queryStr: string, formatResults: boolean = true): Promise<Result<TDataSourceResult>> {
+        let connPool: MsSql.ConnectionPool = null as any as MsSql.ConnectionPool;
+        let recordsets: MsSql.IRecordSet<any>;
+
+        try {
+            connPool = await new MsSql.ConnectionPool(connStr);
+            await connPool.connect();
+            const result: MsSql.IResult<any> = await new MsSql.Request(connPool).query(queryStr);
+            recordsets = await result.recordset;
+        }
+        catch (e) {
+            return await this.onExecuteQueryFail(queryStr, Utilities.getErrorMessage(e), formatResults);
+        }
+        finally {
+            if (Utilities.hasValue(connPool) && connPool.connected) {
+                await connPool.close();
+            }
+        }
+
+        if (!Utilities.hasValue(recordsets)) {
+            return await this.onExecuteQueryFail(queryStr, InfoMessages.QUERY_RESULTS_NULL, formatResults);
+        }
+
+        if (recordsets.length === 1) {
+            const recordset: any = recordsets[0];
+
+            const resultAsJson: any = recordset[MsSqlQueryProvider._jsonColumnId];
+            if (Utilities.hasValue(resultAsJson)) {
+                const ret: TDataSourceResult = {
+                    Json: (formatResults)
+                        ? JSON.stringify(resultAsJson, null, 4)
+                        : JSON.stringify(resultAsJson),
+                    Object: resultAsJson,
+                    Xml: await Utilities.jsonStrToXmlStr(JSON.stringify(resultAsJson), formatResults)
+                };
+
+                return Result.ok<TDataSourceResult>(ret);
+            }
+
+            const resultAsXml: any = recordset[MsSqlQueryProvider._xmlColumnId];
+            if (Utilities.hasValue(resultAsXml)) {
+                const ret: TDataSourceResult = {
+                    Json: Utilities.xmlStrToJsonStr(resultAsXml, formatResults),
+                    Object: resultAsXml,
+                    Xml: (formatResults)
+                        ? await Utilities.formatXml(resultAsXml)
+                        : resultAsXml
+                };
+
+                return Result.ok<TDataSourceResult>(ret);
+            }
+        }
+
+        const ret: TDataSourceResult = {
+            Json: (formatResults)
+                ? JSON.stringify(recordsets, null, 4)
+                : JSON.stringify(recordsets),
+            Object: recordsets,
+            Xml: await Utilities.jsonStrToXmlStr(JSON.stringify(recordsets), formatResults)
+        };
+
+        return Result.ok<TDataSourceResult>(ret);
+    }
+}

--- a/Gentron.UI/index.html
+++ b/Gentron.UI/index.html
@@ -59,6 +59,11 @@
     <link rel="stylesheet" href="./node_modules/metro4/build/css/metro-all.min.css" />
 </head>
 <body style="height: 100%;">
+    <script>
+        const MsSqlQueryProvider = require('../Gentron.Library/queryProviders/MsSqlQueryProvider').default;
+        window.MsSqlQueryProvider = MsSqlQueryProvider;
+    </script>
+
     <script src="http://localhost:8080/webpack-dev-server.js"></script>
     <script src="http://localhost:8080/built/bundle.js"></script>
     <!--<script type="text/javascript" src="./bundle.js"></script>-->

--- a/Gentron.UI/index.tsx
+++ b/Gentron.UI/index.tsx
@@ -14,7 +14,7 @@ import * as ReactDOM from "react-dom";
 
 import { AnyAction, Store } from "redux";
 import { createMemoryHistory, MemoryHistory } from 'history';
-import { Gentron, IGentron } from "../Gentron.Library";
+import { Gentron, IGentron, DatabaseSource } from "../Gentron.Library";
 import { Provider } from 'react-redux';
 import App from "./components/App";
 import configureStore from './store/configureStore';
@@ -47,6 +47,8 @@ const rootId: string = `appRoot${Date.now()}`;
 root.id = rootId;
 root.className = "h-100 w-100";
 document.body.appendChild(root);
+
+(DatabaseSource as any)._msSqlQueryProvider = new (window as any).MsSqlQueryProvider();
 
 ReactDOM.render(
     <Provider store={store}>


### PR DESCRIPTION
Separated query providers out from database sources so that they can be injected into app -- query provider module injection fixes issue with wepback not being able load mssql/msnodesqlv8 modules